### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,20 @@
-.. image:: https://pypip.in/version/jsobject/badge.svg
+.. image:: https://img.shields.io/pypi/v/jsobject.svg
     :target: https://pypi.python.org/pypi/jsobject/
     :alt: Latest Version
 
-.. image:: https://pypip.in/download/jsobject/badge.svg
+.. image:: https://img.shields.io/pypi/dm/jsobject.svg
     :target: https://pypi.python.org/pypi/jsobject/
     :alt: Downloads
 
-.. image:: https://pypip.in/py_versions/jsobject/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/jsobject.svg
     :target: https://pypi.python.org/pypi/jsobject/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/license/jsobject/badge.svg
+.. image:: https://img.shields.io/pypi/l/jsobject.svg
     :target: https://pypi.python.org/pypi/jsobject/
     :alt: License
 
-.. image:: https://pypip.in/status/jsobject/badge.svg
+.. image:: https://img.shields.io/pypi/status/jsobject.svg
     :target: https://pypi.python.org/pypi/jsobject/
     :alt: Development Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20jsobject))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `jsobject`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.